### PR TITLE
v0.3.6

### DIFF
--- a/isoplots/plots/spfit.py
+++ b/isoplots/plots/spfit.py
@@ -122,9 +122,7 @@ def plot(path=None, figsize=(8, 8), output=None):
     # Ensure field data is in nanometers and matches isofit wl
     if df.wl[0] < 100.0:
         df.wl = micron_to_nm(df.wl)
-    if da.wl[0] < 100.0:
-        da.wl = micron_to_nm(da.wl)
-    assert len(df.wl) == len(da.wl), "Field data example wavelengths do not match ISOFIT output data"
+    assert len(df.wl) == len(da.wavelength), "Field data example wavelengths do not match ISOFIT output data"
 
     fig, (ax1, ax2) = plt.subplots(2, 1, figsize=figsize, sharex=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "isoplots"
-version = "0.3.5"
+version = "0.3.6"
 description = "Plot Utilities for ISOFIT"
 readme = "README.rst"
 requires-python = ">=3.9"


### PR DESCRIPTION
Fixed reference to `wl` on isofit reflectance product, which names it `wavelength` instead. Since this is an isofit output, should be safe to assume it is in nanometers